### PR TITLE
Add "Initialize User Secrets" menu item

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Open the user secrets for a project, for more information see the [User Secrets 
 
 ## Changelog
 
+### 1.2.0
+- Added "Initialize User Secrets" menu item
+
 ### 1.1.0
 - Fixed Rider 2021.1 compatibility
 - Support secrets file in Directory.Build.props

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'eu.gillissen.rider'
-version '1.1.0'
+version '1.2.0'
 
 repositories {
     mavenCentral()
@@ -35,6 +35,10 @@ compileTestKotlin {
 patchPluginXml {
     untilBuild null
     changeNotes """
+<b>1.2.0</b>
+<ul>
+    <li>Added "Initialize User Secrets" menu item</li>
+</ul>
 <b>1.1.0</b>
 <ul>
     <li>Fixed Rider 2021.1 compatibility</li>

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,14 @@ buildSearchableOptions {
     enabled = false
 }
 
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
 patchPluginXml {
     untilBuild null
     changeNotes """

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/AnActionEventExtensions.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/AnActionEventExtensions.kt
@@ -1,0 +1,32 @@
+package eu.gillissen.rider.usersecrets
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import javax.xml.parsers.DocumentBuilderFactory
+
+fun AnActionEvent.getActionProjectFile(): VirtualFile? =
+    getData(PlatformDataKeys.VIRTUAL_FILE)
+
+fun AnActionEvent.getActionProject(): Project? =
+    CommonDataKeys.PROJECT.getData(dataContext)
+
+fun AnActionEvent.getXmlUserSecretsIdValue(): String? {
+    val projectFile = getActionProjectFile()
+    val document = DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder()
+        .parse(projectFile!!.inputStream)
+    document.documentElement.normalize()
+
+    val nodes = document.getElementsByTagName(UserSecretsService.UserSecretsIdMsBuildProperty)
+
+    if (nodes.length == 0) {
+        return null
+    }
+
+    val node = nodes.item(0)
+
+    return node.textContent
+}

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/InitUserSecretsAction.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/InitUserSecretsAction.kt
@@ -6,13 +6,12 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
-import com.intellij.openapi.vfs.VirtualFile
 
 class InitUserSecretsAction : AnAction() {
     override fun update(actionEvent: AnActionEvent) {
         actionEvent.presentation.isEnabledAndVisible = false
 
-        if (!isActionSupported(actionEvent)) {
+        if (!UserSecretsService.isActionSupported(actionEvent)) {
             return
         }
 
@@ -27,7 +26,7 @@ class InitUserSecretsAction : AnAction() {
     }
 
     override fun actionPerformed(actionEvent: AnActionEvent) {
-        if (!isActionSupported(actionEvent)) {
+        if (!UserSecretsService.isActionSupported(actionEvent)) {
             return
         }
 
@@ -48,25 +47,5 @@ class InitUserSecretsAction : AnAction() {
                 projectFile.refresh(true, false)
             }
         }.queue()
-    }
-
-    private fun isActionSupported(actionEvent: AnActionEvent): Boolean {
-        val project = actionEvent.getActionProject()
-        if (project == null || project.isDefault) {
-            return false
-        }
-
-        val projectFile = actionEvent.getActionProjectFile()
-        if (projectFile == null || !isActionSupportedForFile(projectFile)) {
-            return false
-        }
-
-        return true
-    }
-
-    private fun isActionSupportedForFile(file: VirtualFile?): Boolean {
-        if (file == null) return false
-
-        return UserSecretsService.supportedFileExtensions.any { it.equals(file.extension, ignoreCase = true) }
     }
 }

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/InitUserSecretsAction.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/InitUserSecretsAction.kt
@@ -1,0 +1,72 @@
+package eu.gillissen.rider.usersecrets
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.vfs.VirtualFile
+
+class InitUserSecretsAction : AnAction() {
+    override fun update(actionEvent: AnActionEvent) {
+        actionEvent.presentation.isEnabledAndVisible = false
+
+        if (!isActionSupported(actionEvent)) {
+            return
+        }
+
+        actionEvent.presentation.isVisible = true
+
+        // If Project already contains <UserSecretsId>
+        if (!actionEvent.getXmlUserSecretsIdValue().isNullOrEmpty()) {
+            return
+        }
+
+        actionEvent.presentation.isEnabledAndVisible = true
+    }
+
+    override fun actionPerformed(actionEvent: AnActionEvent) {
+        if (!isActionSupported(actionEvent)) {
+            return
+        }
+
+        val project = actionEvent.getActionProject()!!
+        val projectFile = actionEvent.getActionProjectFile()!!
+
+        object : Task.Backgroundable(project, "Adding user secrets...", true, DEAF) {
+            override fun run(indicator: ProgressIndicator) {
+                val toolInstalled = UserSecretsService.isUserSecretsToolInstalled()
+                if (!toolInstalled) {
+                    NotificationGroupManager.getInstance().getNotificationGroup("User Secrets Notification Group")
+                        .createNotification("User Secrets global tool not found", NotificationType.ERROR)
+                        .notify(project);
+                    return
+                }
+
+                UserSecretsService.initUserSecrets(projectFile)
+                projectFile.refresh(true, false)
+            }
+        }.queue()
+    }
+
+    private fun isActionSupported(actionEvent: AnActionEvent): Boolean {
+        val project = actionEvent.getActionProject()
+        if (project == null || project.isDefault) {
+            return false
+        }
+
+        val projectFile = actionEvent.getActionProjectFile()
+        if (projectFile == null || !isActionSupportedForFile(projectFile)) {
+            return false
+        }
+
+        return true
+    }
+
+    private fun isActionSupportedForFile(file: VirtualFile?): Boolean {
+        if (file == null) return false
+
+        return UserSecretsService.supportedFileExtensions.any { it.equals(file.extension, ignoreCase = true) }
+    }
+}

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/OpenUserSecretsAction.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/OpenUserSecretsAction.kt
@@ -4,58 +4,27 @@ package eu.gillissen.rider.usersecrets
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.jetbrains.rd.platform.util.application
-import com.jetbrains.rider.run.environment.MSBuildEvaluator
 import java.io.File
-import java.util.concurrent.TimeUnit
-import javax.xml.parsers.DocumentBuilderFactory
 
 class OpenUserSecretsAction : AnAction() {
 
-    companion object {
-        private val supportedFileExtensions = arrayOf("csproj", "vbproj", "fsproj")
-        private val supportedFileNames = arrayOf("Directory.Build.props", "Directory.Build.targets")
-
-        private const val UserSecretsIdMsBuildProperty = "UserSecretsId"
-    }
-
     override fun update(actionEvent: AnActionEvent) {
+        actionEvent.presentation.isEnabledAndVisible = false
 
-        val project = CommonDataKeys.PROJECT.getData(actionEvent.dataContext)
-
-        if (project == null || project.isDefault) {
-            actionEvent.presentation.isEnabledAndVisible = false
+        if (!isActionSupported(actionEvent)) {
             return
         }
 
-        val projectFile = actionEvent.getData(PlatformDataKeys.VIRTUAL_FILE)
-        if (projectFile == null || !isFileSupported(projectFile)) {
-            actionEvent.presentation.isEnabledAndVisible = false
-            return
-        }
+        actionEvent.presentation.isVisible = true
 
-        val document = DocumentBuilderFactory.newInstance()
-            .newDocumentBuilder()
-            .parse(projectFile.inputStream)
-
-        document.documentElement.normalize()
-        val userSecretsIdNodes = document.getElementsByTagName(UserSecretsIdMsBuildProperty)
-        if (userSecretsIdNodes.length == 0) {
-            actionEvent.presentation.isEnabledAndVisible = false
-            return
-        }
-
-        if (userSecretsIdNodes.item(0).textContent.isNullOrEmpty()) {
-            actionEvent.presentation.isEnabled = false
-            actionEvent.presentation.isVisible = true
+        // If Project doesn't contain <UserSecretsId>
+        if (actionEvent.getXmlUserSecretsIdValue().isNullOrEmpty()) {
             return
         }
 
@@ -63,26 +32,20 @@ class OpenUserSecretsAction : AnAction() {
     }
 
     override fun actionPerformed(actionEvent: AnActionEvent) {
+        if (!isActionSupported(actionEvent)) {
+            return
+        }
 
-        val project = CommonDataKeys.PROJECT.getData(actionEvent.dataContext) ?: return
-        if (project.isDefault) return
-
-        val projectFile = actionEvent.getData(PlatformDataKeys.VIRTUAL_FILE) ?: return
-        if (!isFileSupported(projectFile)) return
+        val project = actionEvent.getActionProject()!!
+        val projectFile = actionEvent.getActionProjectFile()!!
 
         object : Task.Backgroundable(project, "Retrieving user secrets...", true, DEAF) {
 
             override fun run(indicator: ProgressIndicator) {
-                val msBuildEvaluator = MSBuildEvaluator.getInstance(project)
-                val msBuildProperties = msBuildEvaluator
-                    .evaluateProperties(MSBuildEvaluator.PropertyRequest(projectFile.path, null, listOf(UserSecretsIdMsBuildProperty)))
-                    .blockingGet(1, TimeUnit.MINUTES)
-                    ?: return
-
-                val secretsId = msBuildProperties[UserSecretsIdMsBuildProperty] ?: return
+                val secretsId = UserSecretsService.getMsbuildUserSecretsIdValue(project, projectFile) ?: return
 
                 application.invokeLaterOnWriteThread {
-                    val secretsDirectoryRoot = getSecretsDirectoryRoot()
+                    val secretsDirectoryRoot = UserSecretsService.getUserSecretsDirectoryRoot()
                     val secretsDirectory = "$secretsDirectoryRoot${File.separatorChar}$secretsId"
                     val secretsFile = File("$secretsDirectory${File.separatorChar}secrets.json")
                     if (!secretsFile.exists()) {
@@ -103,17 +66,24 @@ class OpenUserSecretsAction : AnAction() {
         }.queue()
     }
 
-    private fun isFileSupported(projectFile: VirtualFile?): Boolean {
-        if (projectFile == null) return false
+    private fun isActionSupported(actionEvent: AnActionEvent): Boolean {
+        val project = actionEvent.getActionProject()
+        if (project == null || project.isDefault) {
+            return false
+        }
 
-        return supportedFileExtensions.any { it.equals(projectFile.extension, ignoreCase = true) } ||
-                supportedFileNames.any { it.equals(projectFile.name, ignoreCase = true) }
+        val projectFile = actionEvent.getActionProjectFile()
+        if (projectFile == null || !isActionSupportedForFile(projectFile)) {
+            return false
+        }
+
+        return true
     }
 
-    private fun getSecretsDirectoryRoot(): String {
-        return if (SystemInfo.isWindows)
-            "${System.getenv("APPDATA")}${File.separatorChar}microsoft${File.separatorChar}UserSecrets${File.separatorChar}"
-        else
-            "${System.getenv("HOME")}${File.separatorChar}.microsoft${File.separatorChar}usersecrets${File.separatorChar}"
+    private fun isActionSupportedForFile(projectFile: VirtualFile?): Boolean {
+        if (projectFile == null) return false
+
+        return UserSecretsService.supportedFileExtensions.any { it.equals(projectFile.extension, ignoreCase = true) } ||
+                UserSecretsService.supportedFileNames.any { it.equals(projectFile.name, ignoreCase = true) }
     }
 }

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/OpenUserSecretsAction.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/OpenUserSecretsAction.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VirtualFile
 import com.jetbrains.rd.platform.util.application
 import java.io.File
 
@@ -17,7 +16,7 @@ class OpenUserSecretsAction : AnAction() {
     override fun update(actionEvent: AnActionEvent) {
         actionEvent.presentation.isEnabledAndVisible = false
 
-        if (!isActionSupported(actionEvent)) {
+        if (!UserSecretsService.isActionSupported(actionEvent)) {
             return
         }
 
@@ -32,7 +31,7 @@ class OpenUserSecretsAction : AnAction() {
     }
 
     override fun actionPerformed(actionEvent: AnActionEvent) {
-        if (!isActionSupported(actionEvent)) {
+        if (!UserSecretsService.isActionSupported(actionEvent)) {
             return
         }
 
@@ -64,26 +63,5 @@ class OpenUserSecretsAction : AnAction() {
                 }
             }
         }.queue()
-    }
-
-    private fun isActionSupported(actionEvent: AnActionEvent): Boolean {
-        val project = actionEvent.getActionProject()
-        if (project == null || project.isDefault) {
-            return false
-        }
-
-        val projectFile = actionEvent.getActionProjectFile()
-        if (projectFile == null || !isActionSupportedForFile(projectFile)) {
-            return false
-        }
-
-        return true
-    }
-
-    private fun isActionSupportedForFile(projectFile: VirtualFile?): Boolean {
-        if (projectFile == null) return false
-
-        return UserSecretsService.supportedFileExtensions.any { it.equals(projectFile.extension, ignoreCase = true) } ||
-                UserSecretsService.supportedFileNames.any { it.equals(projectFile.name, ignoreCase = true) }
     }
 }

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/UserSecretsService.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/UserSecretsService.kt
@@ -1,0 +1,50 @@
+package eu.gillissen.rider.usersecrets
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.rdclient.util.idea.toIOFile
+import com.jetbrains.rider.run.environment.MSBuildEvaluator
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+object UserSecretsService {
+    val supportedFileExtensions = arrayOf("csproj", "vbproj", "fsproj")
+    val supportedFileNames = arrayOf("Directory.Build.props", "Directory.Build.targets")
+
+    const val UserSecretsIdMsBuildProperty = "UserSecretsId"
+
+    fun isUserSecretsToolInstalled(): Boolean {
+        val output = Runtime.getRuntime().exec("dotnet user-secrets --version")
+        output.waitFor()
+
+        return output.errorStream.readAllBytes().isEmpty()
+    }
+
+    fun initUserSecrets(projectFile: VirtualFile): Int {
+        val projectDirectory = projectFile.toIOFile().absoluteFile.parentFile
+        val output = Runtime.getRuntime().exec("dotnet user-secrets init", null, projectDirectory)
+        output.waitFor()
+
+        return output.exitValue()
+    }
+
+    fun getMsbuildUserSecretsIdValue(project: Project, projectFile: VirtualFile): String? {
+        val msBuildEvaluator = MSBuildEvaluator.getInstance(project)
+        val msBuildProperties = msBuildEvaluator
+            .evaluateProperties(MSBuildEvaluator.PropertyRequest(projectFile.path, null, listOf(UserSecretsService.UserSecretsIdMsBuildProperty)))
+            .blockingGet(1, TimeUnit.MINUTES)
+            ?: return null
+
+        val secretsId = msBuildProperties[UserSecretsService.UserSecretsIdMsBuildProperty] ?: return null
+
+        return secretsId
+    }
+
+    fun getUserSecretsDirectoryRoot(): String {
+        return if (SystemInfo.isWindows)
+            "${System.getenv("APPDATA")}${File.separatorChar}microsoft${File.separatorChar}UserSecrets${File.separatorChar}"
+        else
+            "${System.getenv("HOME")}${File.separatorChar}.microsoft${File.separatorChar}usersecrets${File.separatorChar}"
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <vendor email="Gillissen.A@gmail.com" url="http://gillissen.eu">Alexander Gillissen</vendor>
 
     <description><![CDATA[
-      Adds ability to Add new and to Open existing User Secrets, for more information see the <a href="https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets">User Secrets documentation</a>.
+      Adds the ability to create and open User Secrets, for more information see the <a href="https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets">User Secrets documentation</a>.
     ]]></description>
 
     <depends>com.intellij.modules.rider</depends>
@@ -16,7 +16,7 @@
     <actions>
         <action id="InitUserSecretsAction" class="eu.gillissen.rider.usersecrets.InitUserSecretsAction"
                 text="Initialize User Secrets"
-                description="Initializes user secrets for given project">
+                description="Initializes user secrets for the project">
             <add-to-group group-id="ProjectViewPopupMenu"/>
         </action>
         <action id="OpenUserSecretsAction" class="eu.gillissen.rider.usersecrets.OpenUserSecretsAction"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,17 +4,23 @@
     <vendor email="Gillissen.A@gmail.com" url="http://gillissen.eu">Alexander Gillissen</vendor>
 
     <description><![CDATA[
-      Open the user secrets for a project, for more information see the <a href="https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets">User Secrets documentation</a>.
+      Adds ability to Add new and to Open existing User Secrets, for more information see the <a href="https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets">User Secrets documentation</a>.
     ]]></description>
 
     <depends>com.intellij.modules.rider</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <notificationGroup id="User Secrets Notification Group" displayType="BALLOON" />
     </extensions>
 
     <actions>
+        <action id="InitUserSecretsAction" class="eu.gillissen.rider.usersecrets.InitUserSecretsAction"
+                text="Initialize User Secrets"
+                description="Initializes user secrets for given project">
+            <add-to-group group-id="ProjectViewPopupMenu"/>
+        </action>
         <action id="OpenUserSecretsAction" class="eu.gillissen.rider.usersecrets.OpenUserSecretsAction"
-                text="Open project user secrets"
+                text="Open Project User Secrets"
                 description="Opens the user secrets file for the project">
             <add-to-group group-id="ProjectViewPopupMenu"/>
         </action>


### PR DESCRIPTION
The PR adds additional menu item to initialize user secrets:

![image](https://user-images.githubusercontent.com/20597871/124981773-9f4ab680-e03e-11eb-88d7-2e0c5de14f20.png)

"Initialize User Secrets" action executes `dotnet user-secrets init` on a supported project file.

I also refactored the current code a bit and moved a generic code into a dedicated service and extensions.

Manually tested according to repository guidelines.

Closes #6