### PR TITLE
Remove dependency on `dotnet user-secrets init` for secrets initialization

### DIFF
--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/AnActionEventExtensions.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/AnActionEventExtensions.kt
@@ -7,20 +7,20 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import javax.xml.parsers.DocumentBuilderFactory
 
-fun AnActionEvent.getActionProjectFile(): VirtualFile? =
+internal fun AnActionEvent.getActionProjectFile(): VirtualFile? =
     getData(PlatformDataKeys.VIRTUAL_FILE)
 
-fun AnActionEvent.getActionProject(): Project? =
+internal fun AnActionEvent.getActionProject(): Project? =
     CommonDataKeys.PROJECT.getData(dataContext)
 
-fun AnActionEvent.getXmlUserSecretsIdValue(): String? {
+internal fun AnActionEvent.getXmlUserSecretsIdValue(): String? {
     val projectFile = getActionProjectFile()
     val document = DocumentBuilderFactory.newInstance()
         .newDocumentBuilder()
         .parse(projectFile!!.inputStream)
     document.documentElement.normalize()
 
-    val nodes = document.getElementsByTagName(UserSecretsService.UserSecretsIdMsBuildProperty)
+    val nodes = document.getElementsByTagName(SharedConstants.UserSecretsIdMsBuildProperty)
 
     if (nodes.length == 0) {
         return null

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/IndentExtensions.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/IndentExtensions.kt
@@ -2,8 +2,8 @@ package eu.gillissen.rider.usersecrets
 
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 
-internal fun CommonCodeStyleSettings.IndentOptions.createIndent(level: Int): String {
-    val indentBase = if (USE_TAB_CHARACTER) "\t" else " "
-
-    return indentBase.repeat(level * INDENT_SIZE)
-}
+internal fun CommonCodeStyleSettings.IndentOptions.createIndent(level: Int): String =
+    if (USE_TAB_CHARACTER)
+        "\t".repeat(level * (INDENT_SIZE / TAB_SIZE))
+    else
+        " ".repeat(level * INDENT_SIZE)

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/IndentExtensions.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/IndentExtensions.kt
@@ -1,0 +1,9 @@
+package eu.gillissen.rider.usersecrets
+
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
+
+fun CommonCodeStyleSettings.IndentOptions.createIndent(level: Int): String {
+    val indentBase = if (USE_TAB_CHARACTER) "\t" else " "
+
+    return indentBase.repeat(level * INDENT_SIZE)
+}

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/IndentExtensions.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/IndentExtensions.kt
@@ -2,7 +2,7 @@ package eu.gillissen.rider.usersecrets
 
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 
-fun CommonCodeStyleSettings.IndentOptions.createIndent(level: Int): String {
+internal fun CommonCodeStyleSettings.IndentOptions.createIndent(level: Int): String {
     val indentBase = if (USE_TAB_CHARACTER) "\t" else " "
 
     return indentBase.repeat(level * INDENT_SIZE)

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/InitUserSecretsAction.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/InitUserSecretsAction.kt
@@ -1,9 +1,8 @@
 package eu.gillissen.rider.usersecrets
 
-import com.intellij.notification.NotificationGroupManager
-import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 
@@ -35,16 +34,9 @@ class InitUserSecretsAction : AnAction() {
 
         object : Task.Backgroundable(project, "Adding user secrets...", true, DEAF) {
             override fun run(indicator: ProgressIndicator) {
-                val toolInstalled = UserSecretsService.isUserSecretsToolInstalled()
-                if (!toolInstalled) {
-                    NotificationGroupManager.getInstance().getNotificationGroup("User Secrets Notification Group")
-                        .createNotification("User Secrets global tool not found", NotificationType.ERROR)
-                        .notify(project);
-                    return
+                ApplicationManager.getApplication().invokeAndWait {
+                    UserSecretsService.initUserSecrets(projectFile, project)
                 }
-
-                UserSecretsService.initUserSecrets(projectFile)
-                projectFile.refresh(true, false)
             }
         }.queue()
     }

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/SharedConstants.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/SharedConstants.kt
@@ -1,0 +1,5 @@
+package eu.gillissen.rider.usersecrets
+
+object SharedConstants {
+    const val UserSecretsIdMsBuildProperty = "UserSecretsId"
+}

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/UserSecretsService.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/UserSecretsService.kt
@@ -1,72 +1,110 @@
 package eu.gillissen.rider.usersecrets
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
-import com.jetbrains.rdclient.util.idea.toIOFile
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
+import com.jetbrains.rd.framework.impl.startAndAdviseSuccess
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rider.model.*
+import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.projectView.workspace.containingEntity
+import com.jetbrains.rider.projectView.workspace.getId
 import com.jetbrains.rider.run.environment.MSBuildEvaluator
+import com.jetbrains.rider.util.idea.getPsiFile
 import java.io.File
+import java.util.*
 import java.util.concurrent.TimeUnit
+import javax.xml.parsers.DocumentBuilderFactory
 
 object UserSecretsService {
-    private val supportedFileExtensions = arrayOf("csproj", "vbproj", "fsproj")
-    private val supportedFileNames = arrayOf("Directory.Build.props", "Directory.Build.targets")
+    private val projectFileExtensions = arrayOf("csproj", "vbproj", "fsproj")
+    private val sharedPropertiesFileNames = arrayOf("Directory.Build.props", "Directory.Build.targets")
 
-    const val UserSecretsIdMsBuildProperty = "UserSecretsId"
+    internal fun initUserSecrets(file: VirtualFile, project: Project) {
+        if (projectFileExtensions.contains(file.extension)) {
+            return initUserSecretsUsingMsBuild(file, project)
+        }
 
-    fun isUserSecretsToolInstalled(): Boolean {
-        val output = Runtime.getRuntime().exec("dotnet user-secrets --version")
-        output.waitFor()
-
-        return output.errorStream.readAllBytes().isEmpty()
+        // Rider do not currently support editing of Directory.Build.* files through API
+        if (sharedPropertiesFileNames.contains(file.name)) {
+            return initUserSecretsUsingXml(file, project)
+        }
     }
 
-    fun initUserSecrets(projectFile: VirtualFile): Int {
-        val projectIoFile = projectFile.toIOFile()
-        val fullProjectFilePath = projectIoFile.absolutePath
-        val projectDirectory = projectIoFile.absoluteFile.parentFile
-        val output = Runtime.getRuntime().exec("dotnet user-secrets init --project \"${fullProjectFilePath}\"", null, projectDirectory)
-        output.waitFor()
-
-        return output.exitValue()
-    }
-
-    fun getMsbuildUserSecretsIdValue(project: Project, projectFile: VirtualFile): String? {
+    internal fun getMsbuildUserSecretsIdValue(project: Project, file: VirtualFile): String? {
         val msBuildEvaluator = MSBuildEvaluator.getInstance(project)
         val msBuildProperties = msBuildEvaluator
-            .evaluateProperties(MSBuildEvaluator.PropertyRequest(projectFile.path, null, listOf(UserSecretsService.UserSecretsIdMsBuildProperty)))
+            .evaluateProperties(MSBuildEvaluator.PropertyRequest(file.path, null, listOf(SharedConstants.UserSecretsIdMsBuildProperty)))
             .blockingGet(1, TimeUnit.MINUTES)
             ?: return null
 
-        return msBuildProperties[UserSecretsService.UserSecretsIdMsBuildProperty]
+        return msBuildProperties[SharedConstants.UserSecretsIdMsBuildProperty]
     }
 
-    fun getUserSecretsDirectoryRoot(): String {
+    internal fun getUserSecretsDirectoryRoot(): String {
         return if (SystemInfo.isWindows)
             "${System.getenv("APPDATA")}${File.separatorChar}microsoft${File.separatorChar}UserSecrets${File.separatorChar}"
         else
             "${System.getenv("HOME")}${File.separatorChar}.microsoft${File.separatorChar}usersecrets${File.separatorChar}"
     }
 
-    fun isActionSupported(actionEvent: AnActionEvent): Boolean {
+    internal fun isActionSupported(actionEvent: AnActionEvent): Boolean {
         val project = actionEvent.getActionProject()
         if (project == null || project.isDefault) {
             return false
         }
 
         val projectFile = actionEvent.getActionProjectFile()
-        if (projectFile == null || !UserSecretsService.isActionSupportedForFile(projectFile)) {
+        if (projectFile == null || !isActionSupportedForFile(projectFile)) {
             return false
         }
 
         return true
     }
 
+    private fun initUserSecretsUsingMsBuild(file: VirtualFile, project: Project) {
+        val projectModelEntity = file.containingEntity(project) ?: return
+        val projectId = projectModelEntity.getId(project) ?: return
+        val changeUserSecret = RdChangeProjectProperty(SharedConstants.UserSecretsIdMsBuildProperty, UUID.randomUUID().toString())
+        val propertiesToUpdate = listOf(changeUserSecret)
+        val command = RdChangeProjectPropertiesCommand(projectId, propertiesToUpdate)
+        Lifetime.using { lifetime ->
+            project.solution.projectModelTasks.changeProjectProperties.startAndAdviseSuccess(lifetime, command) {
+                file.refresh(true, false)
+            }
+        }
+    }
+
+    private fun initUserSecretsUsingXml(file: VirtualFile, project: Project) {
+        val documentBuilderFactory = DocumentBuilderFactory.newInstance()
+        val document = documentBuilderFactory
+            .newDocumentBuilder()
+            .parse(file.inputStream)
+
+        val indentOptions = getIndentOptions(file, FileDocumentManager.getInstance(), PsiDocumentManager.getInstance(project))
+        val propertyGroup = document.getOrCreatePropertyGroup(indentOptions)
+        document.insertUserSecrets(propertyGroup, UUID.randomUUID().toString(), indentOptions)
+        document.saveToFile(file.path)
+        file.refresh(false, false)
+    }
+
+    private fun getIndentOptions(file: VirtualFile, fileDocumentManager: FileDocumentManager, psiDocumentManager: PsiDocumentManager): CommonCodeStyleSettings.IndentOptions =
+        CommonCodeStyleSettings.IndentOptions
+            .retrieveFromAssociatedDocument(
+                file.getPsiFile(
+                    fileDocumentManager,
+                    psiDocumentManager
+                )!!
+            ) ?: CommonCodeStyleSettings.IndentOptions.DEFAULT_INDENT_OPTIONS
+
     private fun isActionSupportedForFile(projectFile: VirtualFile?): Boolean {
         if (projectFile == null) return false
 
-        return UserSecretsService.supportedFileExtensions.any { it.equals(projectFile.extension, ignoreCase = true) } ||
-                UserSecretsService.supportedFileNames.any { it.equals(projectFile.name, ignoreCase = true) }
+        return projectFileExtensions.any { it.equals(projectFile.extension, ignoreCase = true) } ||
+                sharedPropertiesFileNames.any { it.equals(projectFile.name, ignoreCase = true) }
     }
 }

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/XmlExtensions.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/XmlExtensions.kt
@@ -25,7 +25,7 @@ internal fun Document.insertUserSecrets(propertyGroup: Node, value: String, inde
     val newUserSecretsId = createElement(SharedConstants.UserSecretsIdMsBuildProperty)
     newUserSecretsId.textContent = value
 
-    return propertyGroup.insertLastIndented(newUserSecretsId, this, indentOptions)
+    return propertyGroup.insertLastIndented(newUserSecretsId, indentOptions)
 }
 
 internal fun Document.insertPropertyGroup(indentOptions: CommonCodeStyleSettings.IndentOptions): Node {
@@ -59,14 +59,14 @@ internal fun Node.insertFirstIndented(child: Node, indentOptions: CommonCodeStyl
     return insertChildAfterIndent(ownerDocument, child, insertedIndentNode, parentIndent)
 }
 
-internal fun Node.insertLastIndented(child: Node, doc: Document, indentOptions: CommonCodeStyleSettings.IndentOptions): Node {
+internal fun Node.insertLastIndented(child: Node, indentOptions: CommonCodeStyleSettings.IndentOptions): Node {
     val parentIndent = this.getOuterIndent()
     val childIndent = indentOptions.createIndent(1)
-    val childIndentNode = doc.createTextNode("$parentIndent$childIndent")
+    val childIndentNode = ownerDocument.createTextNode("$parentIndent$childIndent")
 
     val insertedIndentNode = insertBeforeLastText(childIndentNode)
 
-    return insertChildAfterIndent(doc, child, insertedIndentNode, parentIndent)
+    return insertChildAfterIndent(ownerDocument, child, insertedIndentNode, parentIndent)
 }
 
 internal fun NodeList.first(predicate: (Node) -> Boolean): Node? {

--- a/src/main/kotlin/eu/gillissen/rider/usersecrets/XmlExtensions.kt
+++ b/src/main/kotlin/eu/gillissen/rider/usersecrets/XmlExtensions.kt
@@ -1,0 +1,127 @@
+package eu.gillissen.rider.usersecrets
+
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
+import org.w3c.dom.Document
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
+import org.w3c.dom.Text
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
+private const val propertyGroupNodeName = "PropertyGroup"
+private const val conditionAttributeName = "Condition"
+
+internal fun Document.getOrCreatePropertyGroup(indentOptions: CommonCodeStyleSettings.IndentOptions): Node {
+    val propertyGroupNodes = getElementsByTagName(propertyGroupNodeName)
+    return propertyGroupNodes.first { !it.hasAttribute(conditionAttributeName) }
+        ?: insertPropertyGroup(indentOptions)
+}
+
+internal fun Document.insertUserSecrets(propertyGroup: Node, value: String, indentOptions: CommonCodeStyleSettings.IndentOptions): Node {
+    val newUserSecretsId = createElement(SharedConstants.UserSecretsIdMsBuildProperty)
+    newUserSecretsId.textContent = value
+
+    return propertyGroup.insertLastIndented(newUserSecretsId, this, indentOptions)
+}
+
+internal fun Document.insertPropertyGroup(indentOptions: CommonCodeStyleSettings.IndentOptions): Node {
+    val newPropertyGroup = createElement(propertyGroupNodeName)
+
+    return documentElement.insertFirstIndented(newPropertyGroup, indentOptions)
+}
+
+internal fun Document.saveToFile(path: String) {
+    val transformerFactory = TransformerFactory.newInstance()
+    val transformer = transformerFactory.newTransformer()
+    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")
+    transformer.setOutputProperty(OutputKeys.METHOD, "xml")
+    transformer.setOutputProperty(OutputKeys.INDENT, "no")
+    val source = DOMSource(this)
+    val writer = OutputStreamWriter(FileOutputStream(path))
+    val result = StreamResult(writer)
+
+    transformer.transform(source, result)
+
+    writer.close()
+}
+
+internal fun Node.insertFirstIndented(child: Node, indentOptions: CommonCodeStyleSettings.IndentOptions): Node {
+    val parentIndent = this.getOuterIndent()
+    val childIndent = indentOptions.createIndent(1)
+    val childIndentNode = ownerDocument.createTextNode("$parentIndent$childIndent")
+
+    val insertedIndentNode = insertFirst(childIndentNode)
+
+    return insertChildAfterIndent(ownerDocument, child, insertedIndentNode, parentIndent)
+}
+
+internal fun Node.insertLastIndented(child: Node, doc: Document, indentOptions: CommonCodeStyleSettings.IndentOptions): Node {
+    val parentIndent = this.getOuterIndent()
+    val childIndent = indentOptions.createIndent(1)
+    val childIndentNode = doc.createTextNode("$parentIndent$childIndent")
+
+    val insertedIndentNode = insertBeforeLastText(childIndentNode)
+
+    return insertChildAfterIndent(doc, child, insertedIndentNode, parentIndent)
+}
+
+internal fun NodeList.first(predicate: (Node) -> Boolean): Node? {
+    for (i in 0 until this.length) {
+        val currentNode = this.item(i)
+        if (predicate(currentNode)) {
+            return currentNode
+        }
+    }
+
+    return null
+}
+
+internal fun Node.hasAttribute(attributeName: String): Boolean {
+    val attributes = this.attributes
+    for (i in 0 until attributes.length) {
+        val currentAttribute = attributes.item(i)
+        if (currentAttribute.nodeName == attributeName) {
+            return true
+        }
+    }
+
+    return false
+}
+
+internal fun Node.insertAfter(node: Node, afterNode: Node): Node =
+    insertBefore(node, afterNode.nextSibling)
+
+internal fun Node.insertFirst(otherNode: Node): Node =
+    insertBefore(otherNode, firstChild)
+
+internal fun Node.insertBeforeLastText(node: Node): Node {
+    var candidate = lastChild ?: return appendChild(node)
+
+    while (candidate.previousSibling is Text && candidate.previousSibling.parentNode == parentNode) {
+        candidate = candidate.previousSibling
+    }
+
+    return insertBefore(node, candidate)
+}
+
+internal fun Node.getOuterIndent(): String {
+    val indentNode = previousSibling as Text?
+    return "\n${indentNode?.textContent?.split("\n")?.last() ?: ""}"
+}
+
+private fun Node.insertChildAfterIndent(doc: Document, child: Node, insertedIndentNode: Node, parentIndent: String): Node {
+    val insertedChildNode = insertAfter(child, insertedIndentNode)
+    val potentialIndentNode = insertedChildNode.nextSibling as Text?
+    if (potentialIndentNode !is Text || !potentialIndentNode.isIndent() || !potentialIndentNode.textContent.startsWith(parentIndent)) {
+        insertAfter(doc.createTextNode(parentIndent), insertedChildNode)
+    }
+
+    return insertedChildNode
+}
+
+private fun Text.isIndent(): Boolean =
+    textContent.contains("\n") && textContent.trim().isEmpty()


### PR DESCRIPTION
This PR removes the dependency on `dotnet user-secrets init` command-line call and allows the use of this plugin on .NET Core versions prior to 3.0. 

Now UserSecretsId will be inserted using one of 2 flows:
- **For project files**: `UserSecretsId` node will be added using Rider API for project properties. The same that Rider uses for project properties' UI
- **For shared (`Directory.Build.*`) properties files**: `UserSecretsId` will be added manually using Java XML DOM API. 

The first approach is preferable in all supported cases. The second approach will be used temporarily until the Rider team introduce API for editing `Directory.Buiild.*` files.

Even the second approach works better than `dotnet user-secrets init`, because `init` does not respect formatting (it just adds hardcoded whitespace, see [here](https://github.com/dotnet/aspnetcore/blob/main/src/Tools/dotnet-user-secrets/src/Internal/InitCommand.cs#L123)). I tried to solve the formatting problem as much as Java XML DOM API allowed me to do that.

Basically, there are some formatting drawbacks (e.g. ignoring whitespace before the self-closing tag,  `<Tag />` will be transformed into `<Tag/>` on saving) but such tradeoffs are not critical for a temporary solution.

Closes #21 